### PR TITLE
Fixed graceful disconnections from client.py

### DIFF
--- a/libclient.py
+++ b/libclient.py
@@ -92,10 +92,10 @@ class Message:
     
     def _process_response_json_content(self):
         content = self.response
-        
         if "connect" in content:
             print(f"{content.get('connect')} \n {content.get('players')}")
         if "result" in content:
+            print()     # New line
             print(content.get("result"))               
         
 

--- a/libserver.py
+++ b/libserver.py
@@ -121,6 +121,9 @@ class Message:
             self.game_state.game.set_player_ready(self.game_state.connected_clients.index(self))
             content = {"result": f'Marked Player {self.game_state.connected_clients.index(self) + 1} as ready.'}
         
+        elif action == "exit":
+            content = {"result": "Goodbye!"}
+            self.close()
         else:
             content = {"result": f"Unknown action: '{action}'."}
                 
@@ -169,7 +172,7 @@ class Message:
         self._write()
         
     def close(self):
-        message = f"closing connection to {self.addr}"
+        message = f"Server has closed connection to {self.addr}"
         print(message)
         self.game_state.broadcast_message(message)
         


### PR DESCRIPTION
Quick fix to re-add graceful disconnection attempts when a client sends the 'Exit' command, which was broken in the recent asyncio refactor. 