### PR TITLE
Removed join as a command

### DIFF
--- a/client.py
+++ b/client.py
@@ -8,26 +8,27 @@ from prompt_toolkit import PromptSession
 from prompt_toolkit.patch_stdout import patch_stdout
 
 sel = selectors.DefaultSelector()
-valid_requests = ['join','status', 'ready', 'exit']
+all_valid_requests = ['join', 'status', 'ready', 'exit']
+valid_requests = ['status', 'ready', 'exit']
 client_disconnect = False
 
 async def get_user_input(session):
     while True:
-        user_input = await session.prompt_async(f"Enter command {valid_requests}: ")
+        user_input = await session.prompt_async(f"Enter a command {valid_requests}: ")
         if user_input in valid_requests:
             return user_input
         else:
             print(f"Invalid command. Try {valid_requests}.")
 
 def create_request(action):
-    if action in valid_requests:
+    if action in all_valid_requests:
         return dict(
             type="text/json",
             encoding="utf-8",
             content=dict(action=action)
         )
     else:
-        print(f"Unrecognized command. Currently supported commands include: {valid_requests}")
+        print(f"Unrecognized command. Currently supported commands include: {all_valid_requests}")
         sys.exit(1)
         
 def initialize_connection(host, port, request):

--- a/libserver.py
+++ b/libserver.py
@@ -108,7 +108,9 @@ class Message:
         action = self.request.get("action")
         
         if action == "join":
-            if (len(self.game_state.connected_clients) < self.game_state.game.num_players):
+            if self in self.game_state.connected_clients:
+                content = {"result": "Already joined table"}
+            elif (len(self.game_state.connected_clients) < self.game_state.game.num_players):
                 self.game_state.connected_clients.append(self)
                 self.game_state.broadcast_to_others(f'{self.addr} has joined the table', self.game_state.connected_clients.index(self),tag='debug')
                 content = {"connect": "Welcome to TCPoker!","players": f'You are Player #{self.game_state.connected_clients.index(self) + 1}\nThere are {len(self.game_state.connected_clients)}/{self.game_state.game.num_players} player(s) connected.'}

--- a/poker_offline.py
+++ b/poker_offline.py
@@ -179,6 +179,7 @@ class TexasHoldEm:
         
         self.show_player_hands()   # TODO: Delete this when client functionality implemented
 
+        self.betting_round()
         print("Pre-flop completed") 
         print(f"Current pot is: ${self.pot}")
         


### PR DESCRIPTION
Closes #13 
Client automatically sends 'join' command to join the table upon executing the script and making initial connection. Makes things less confusing. 