### PR TITLE
Implemented betting round logic

### DIFF
--- a/client.py
+++ b/client.py
@@ -95,6 +95,10 @@ class TCPokerClient:
             if message["action"] == "collect_ante":
                 print(f"\nYou must bet the ante ({message['amount']}) to participate in this hand.")
                 self.valid_commands = ['ante']
+            elif message["action"] == "collect_bets":
+                print(f"It's your turn!\nThe pot is ${message['pot']}\nThe current bet is ${message['current_bet']}")
+                self.valid_commands = message["valid_actions"]
+
         elif "game_state" in message:
             if message["game_state"] == "lobby":
                 print("\nReturning to lobby...")

--- a/server.py
+++ b/server.py
@@ -244,7 +244,7 @@ class TCPokerServer:
         await self.current_player_event.wait()
 
     
-    def should_end_round(self, player):
+    def should_end_round(self, current_player):
         ''' Determine if betting round should end 
             A round should end if:
             1. All players but one have folded
@@ -264,8 +264,10 @@ class TCPokerServer:
         # If there's been betting action
         if self.last_bettor:
             # Check we've gone back to the last bettor and all players have matched
-            all_matched = all(self.pot_committed[p] == self.current_bet for p in active_players)
-            return all_matched
+            is_last_bettor = current_player == self.last_bettor
+            all_bets_matched = all(self.pot_committed[p] == self.current_bet for p in active_players)
+            return is_last_bettor and all_bets_matched
+
         return False
     
     def get_valid_actions(self, player):

--- a/server.py
+++ b/server.py
@@ -11,6 +11,8 @@ logging.basicConfig(
     format='%(asctime)s - %(levelname)s - %(message)s'
     )
 
+
+
 class Player:
     ''' Manages state of each player '''
     def __init__(self, name, writer, stack=100):
@@ -20,6 +22,10 @@ class Player:
         self.stack = stack  
         self.hand = []
         self.ante_placed = False
+        self.last_action = None
+        self.folded = False
+
+
 
 class TCPokerServer:
     ''' Manages state of the Poker Game '''
@@ -30,9 +36,15 @@ class TCPokerServer:
         self.ante = 10
         self.random = random.Random(seed)
         self.deck = self.create_deck()
-        self.ante_event = asyncio.Event()
+        self.ante_event = asyncio.Event()   # Signals when all antes are collected
         self.game_task = None
-        
+        self.current_player_event = asyncio.Event()     # Signals when current players turn is over
+        self.current_player = None
+        self.current_bet = 0
+        self.pot_committed = {}     # How much each player has bet during each round
+        self.round_complete = False
+        self.last_bettor = None
+
         
     def cleanup(self):
         ''' Cleans up server state if a game in-progress is cancelled '''
@@ -47,11 +59,13 @@ class TCPokerServer:
         for player in self.players:
             player.hand = []
         
+
     def check_all_ante(self):
         if all(player.ante_placed for player in self.players):
             self.ante_event.set()
         else:
             self.ante_event.clear()
+
 
     def create_deck(self):
         ''' Create and shuffle a deck '''
@@ -60,6 +74,7 @@ class TCPokerServer:
         deck = [f"{rank}{suit}" for suit in suits for rank in ranks]
         self.random.shuffle(deck)
         return deck
+
 
     async def handle_client(self, reader, writer):
         ''' Main client event handler. Each time a client connects, this couroutine is started '''
@@ -107,6 +122,7 @@ class TCPokerServer:
             writer.close()
             await writer.wait_closed()
 
+
     async def process_message(self, player, message):
         ''' Processes any commands received after username stage. The list of commands a client is allowed to send is managed by the client'''
         if "command" in message:
@@ -135,10 +151,22 @@ class TCPokerServer:
                     logging.info(f"{player.name} bets ${amount}. Pot: ${self.pot}")
                 else:
                     await self.send_message(player, {"error": "Bet amount exceeds stack."})
+            elif command in ['check', 'bet', 'call', 'raise', 'fold']:
+                if player == self.current_player:
+                    amount = int(message["command"][1]) if len(message["command"]) > 1 else 0
+                    if self.handle_betting_action(player, command, amount):
+                        self.current_player_event.set()
+                        logging.info(f"{player.name} has {command} ${amount}. Pot: ${self.pot}")
+                        await self.broadcast({"broadcast": f"{player.name} has {command} ${amount}. Pot: ${self.pot}"})
+                    else:
+                        await self.send_message(player, {"error": "Invalid betting action"})
+                else:
+                    await self.send_message(player, {"error": "Please wait your turn"})
             else:
                 await self.send_message(player, {"error": "Unknown command."})
         else:
             await self.send_message(player, {"error": "Invalid message format."})
+
 
     async def check_all_ready(self):
         ''' Check if all clients are ready to start the game '''
@@ -146,6 +174,7 @@ class TCPokerServer:
             self.game_active = True
             await self.broadcast({"start_game": True})      # Notify clients that game has started
             self.game_task = asyncio.create_task(self.start_game())
+
 
     async def start_game(self):
         ''' Main Poker game flow'''
@@ -156,6 +185,9 @@ class TCPokerServer:
         await self.ante_event.wait() 
         # Then, deal hole cards after all antes are collected
         await self.deal_hands()
+
+        await self.broadcast({"broadcast": "Beginning first betting round..."})
+        await self.betting_round()
         
 
     async def deal_hands(self):
@@ -165,10 +197,140 @@ class TCPokerServer:
             await self.send_message(player, {"hand": player.hand})
             logging.info(f"Dealt to {player.name}: {player.hand}")
 
+    
+    async def betting_round(self):
+        ''' Manages betting round '''
+        self.current_bet = 0
+        self.pot_committed = {player: 0 for player in self.players}
+        self.round_complete = False
+        for p in self.players:
+            p.last_action = None
+        self.last_bettor = None
+
+        while not self.round_complete:
+            for player in self.players:
+                if self.round_complete:
+                    break
+                await self.handle_player_turn(player)
+
+
+    async def handle_player_turn(self, player):
+        ''' Handle individual player's turn '''
+        if player.folded:
+            return
+        
+        # Check if round should end before each turn
+        if self.should_end_round(player):
+            self.round_complete = True
+            await self.broadcast({"broadcast": f"Betting round complete. Pot is ${self.pot}"})
+            return
+        
+        self.current_player = player
+        self.current_player_event.clear()
+
+        # Determine valid actions
+        valid_actions = self.get_valid_actions(player)
+
+        # Send turn message to player
+        await self.send_message(player, {
+            "action": "collect_bets",
+            "valid_actions": valid_actions,
+            "current_bet": self.current_bet,
+            "to_call": self.current_bet - self.pot_committed[player],
+            "pot": self.pot
+        })
+
+        # Wait for client action
+        await self.current_player_event.wait()
+
+    
+    def should_end_round(self, player):
+        ''' Determine if betting round should end 
+            A round should end if:
+            1. All players but one have folded
+            2. All players check, no one bets
+            3. All active players have acted and their bet amounts are equal.
+        '''
+        active_players = [p for p in self.players if not p.folded]
+
+        # End round if all players but one have folded
+        if len(active_players) == 1:
+            return True
+        
+        # End round if no bets have been made and all players have checked
+        if self.current_bet == 0 and all(p.last_action == 'check' for p in active_players):
+            return True
+
+        # If there's been betting action
+        if self.last_bettor:
+            # Check we've gone back to the last bettor and all players have matched
+            all_matched = all(self.pot_committed[p] == self.current_bet for p in active_players)
+            return all_matched
+        return False
+    
+    def get_valid_actions(self, player):
+        ''' Determine valid actions for player '''
+        if player.folded:
+            return []
+        
+        to_call = self.current_bet - self.pot_committed[player]
+
+        if self.current_bet == 0:
+            return ['check', 'bet']
+        elif to_call > player.stack:
+                return ['fold']
+        elif player.stack >= to_call * 2: # must have enough to raise
+            return ['call', 'raise', 'fold']
+        else:
+            return ['call', 'fold']
+            
+
+    def handle_betting_action(self, player, action, amount):
+        ''' Handle betting round actions '''
+        if action == 'check' and self.current_bet == 0:
+            player.last_action = 'check'
+            return True
+        elif action == 'bet' and self.current_bet == 0:
+            if amount >= self.ante and amount <= player.stack:
+                self.current_bet = amount
+                self.pot += amount
+                self.pot_committed[player] = amount
+                player.stack -= amount
+                player.last_action = 'bet'
+                self.last_bettor = player
+                return True
+        elif action == 'call' and self.current_bet > 0:
+            to_call = self.current_bet - self.pot_committed[player]
+            if to_call <= player.stack:
+                self.pot += to_call
+                self.pot_committed[player] = self.current_bet
+                player.stack -= to_call
+                player.last_action = 'call'
+                return True
+        elif action == 'raise':
+            if amount >= self.current_bet * 2 and amount <= player.stack:
+                to_add = amount - self.pot_committed[player]
+                self.pot += to_add
+                self.current_bet = amount
+                self.pot_committed[player] = amount
+                player.stack -= to_add
+                player.last_action = 'raise'
+                self.last_bettor = player
+                return True
+        elif action == 'fold':
+            # TODO: implement fold logic
+            player.folded = True
+            player.last_action = 'fold'
+            return True
+        
+        return False
+
+
     async def broadcast(self, message):
         ''' Send a message to all players '''
         for player in self.players:
             await self.send_message(player, message)
+
 
     async def send_message(self, player, message):
         ''' Send a message to a specific player '''
@@ -178,6 +340,8 @@ class TCPokerServer:
             logging.info(f"Sent to {player.name}: {message}")
         except Exception as e:
             logging.error(f"Failed to send message to {player.name}: {e}")
+
+
 
 
 async def main():
@@ -195,7 +359,8 @@ async def main():
     
     async with server:
         await server.serve_forever()
-    
+
+
 if __name__ == "__main__":
     try:
         asyncio.run(main())


### PR DESCRIPTION
Implemented betting round logic to client.py and server.py.
Adds several global variables to the poker server, such as tracking the current player, how much each player has committed, who last raised the pot, what the current bet is, etc
Betting rounds are where the main gameplay takes place, so there is quite a bit of logic added
Every time it's the players turn, they will see the list of valid moves they can make via get_valid_actions()
Betting rounds go until an end-round condition is met inside of should_end_round()
After betting_round() prompts the player whose turn it is, we wait until the client has responded with their action for the turn via an asyncio event. Bet actions from the client are handled by handle_betting_action()