### PR TITLE
Implemented support for playing multiple rounds of poker

### DIFF
--- a/client.py
+++ b/client.py
@@ -112,6 +112,9 @@ class TCPokerClient:
                 print(f"\nTime to send your best 5-card Poker hand!\nChoose 5 cards from your hand (h1, h2) and the community cards (c1, c2, c3, c4, c5)\nExample command format: hand c1 c2 c3 h1 h2")
                 self.valid_commands = ['hand']
 
+            elif message["action"] == "clear_prompt":
+                self.valid_commands = []
+
         elif "game_state" in message:
             if message["game_state"] == "lobby":
                 print("\nReturning to lobby...")

--- a/server.py
+++ b/server.py
@@ -58,6 +58,10 @@ class TCPokerServer:
         self.game_active = False
         for player in self.players:
             player.hand = []
+            player.ante_placed = False
+            player.hand_placed = False
+            player.last_action = None
+            player.folded = False
         if self.game_task:
             self.game_task.cancel()
             self.game_task = None
@@ -501,7 +505,6 @@ class TCPokerServer:
         winner_player.stack += self.pot
         await self.send_message(winner_player, {"broadcast":f"Congratulations on winning! You won ${self.pot}. You now have ${winner_player.stack} in your stack."})
 
-        # TODO: After one game ends, ensure another round starts up smoothly
         await self.broadcast({"broadcast": "Ending current round, ready up to play another!"})
         await self.broadcast({"game_state": "lobby"})
         self.dealer_position += 1


### PR DESCRIPTION
Now correctly alternates between each client for each game of poker. Cleanup() is now properly done, so multiple rounds of poker can be played one after another. Sends clients back to the lobby and makes them ready up to start a new round, or exit. 